### PR TITLE
Enable resizing of admin rectangles

### DIFF
--- a/public/styles/juza.css
+++ b/public/styles/juza.css
@@ -74,6 +74,21 @@
   background: rgba(174, 39, 39, 0.15);
   cursor: move;
 }
+.rect .ui-resizable-handle {
+  background: #ae2727;
+  border: 1px solid #ae2727;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.rect .ui-resizable-n { cursor: n-resize; top: -5px; left: 50%; margin-left: -4px; }
+.rect .ui-resizable-s { cursor: s-resize; bottom: -5px; left: 50%; margin-left: -4px; }
+.rect .ui-resizable-e { cursor: e-resize; right: -5px; top: 50%; margin-top: -4px; }
+.rect .ui-resizable-w { cursor: w-resize; left: -5px; top: 50%; margin-top: -4px; }
+.rect .ui-resizable-se { cursor: se-resize; right: -5px; bottom: -5px; }
+.rect .ui-resizable-sw { cursor: sw-resize; left: -5px; bottom: -5px; }
+.rect .ui-resizable-ne { cursor: ne-resize; right: -5px; top: -5px; }
+.rect .ui-resizable-nw { cursor: nw-resize; left: -5px; top: -5px; }
 
 .rect .x {
   position: absolute;

--- a/views/juza.ejs
+++ b/views/juza.ejs
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/styles/header.css" />
     <link rel="stylesheet" href="/styles/sidebar.css" />
     <link rel="stylesheet" href="/styles/juza.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/themes/base/jquery-ui.min.css" />
     <title>Juza editor</title>
   </head>
   <body>
@@ -223,6 +224,13 @@
               updateCoords($d, idx);
             },
           });
+          $d.resizable({
+            handles: "n,e,s,w,se,sw,ne,nw",
+            containment: "parent",
+            stop() {
+              updateCoords($d, idx);
+            },
+          });
           $d.on("click", ".x", function (e) {
             e.stopPropagation();
             currentRects.splice(idx, 1);
@@ -245,6 +253,8 @@
             ...currentRects[idx],
             x: $d.position().left / vw,
             y: $d.position().top / vh,
+            w: $d.width() / vw,
+            h: $d.height() / vh,
           };
           pageRects[currentPageId] = currentRects;
         }


### PR DESCRIPTION
## Summary
- allow admin hotspots to be resized
- style resize handles for rectangles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a8303fffc8322909cb250d5cc3f98