### PR TITLE
Add duplicate button and single resize handle

### DIFF
--- a/public/styles/juza.css
+++ b/public/styles/juza.css
@@ -106,6 +106,17 @@
   font-size: 0.7rem;
   cursor: pointer;
 }
+.rect .dup {
+  position: absolute;
+  right: -10px;
+  bottom: -10px;
+  background: #fff;
+  border: 1px solid #ae2727;
+  border-radius: 50%;
+  padding: 0 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
 
 #ghost {
   position: absolute;

--- a/views/juza.ejs
+++ b/views/juza.ejs
@@ -215,7 +215,7 @@
         }
         function addRectDom(r, idx) {
           const $d = $(
-            `<div class="rect"><span class="x">✕</span></div>`
+            `<div class="rect"><span class="x">✕</span><span class="dup">⧉</span></div>`
           ).appendTo($viewer);
           positionRect($d, r);
           $d.draggable({
@@ -225,7 +225,7 @@
             },
           });
           $d.resizable({
-            handles: "n,e,s,w,se,sw,ne,nw",
+            handles: "nw",
             containment: "parent",
             stop() {
               updateCoords($d, idx);
@@ -234,6 +234,13 @@
           $d.on("click", ".x", function (e) {
             e.stopPropagation();
             currentRects.splice(idx, 1);
+            pageRects[currentPageId] = currentRects;
+            renderRects();
+          });
+          $d.on("click", ".dup", function (e) {
+            e.stopPropagation();
+            const copy = { ...r };
+            currentRects.push(copy);
             pageRects[currentPageId] = currentRects;
             renderRects();
           });


### PR DESCRIPTION
## Summary
- allow only a single resize handle on audio rectangles
- add new duplicate button in every rectangle
- style duplicate button in the editor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a8732b8648322b4825df8901d5281