### PR TITLE
Add hotspot audio playback and improved duplication

### DIFF
--- a/public/styles/juza.css
+++ b/public/styles/juza.css
@@ -117,6 +117,17 @@
   font-size: 0.7rem;
   cursor: pointer;
 }
+.rect .play {
+  position: absolute;
+  left: -10px;
+  bottom: -10px;
+  background: #fff;
+  border: 1px solid #ae2727;
+  border-radius: 50%;
+  padding: 0 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
 
 #ghost {
   position: absolute;

--- a/views/juza.ejs
+++ b/views/juza.ejs
@@ -114,6 +114,7 @@
 
         /* ---------- persistent audio -------------------------------- */
         let selectedAudio = "";
+        const audio = new Audio();
 
         /* ---------- page strip -------------------------------------- */
         const $strip = $("#page-strip");
@@ -215,7 +216,9 @@
         }
         function addRectDom(r, idx) {
           const $d = $(
-            `<div class="rect"><span class="x">✕</span><span class="dup">⧉</span></div>`
+            '<div class="rect"><span class="x">✕</span><span class="dup">⎘</span>' +
+              (r.audio ? '<span class="play">🔊</span>' : '') +
+            '</div>'
           ).appendTo($viewer);
           positionRect($d, r);
           $d.draggable({
@@ -239,10 +242,17 @@
           });
           $d.on("click", ".dup", function (e) {
             e.stopPropagation();
-            const copy = { ...r };
+            const copy = { ...currentRects[idx] };
             currentRects.push(copy);
             pageRects[currentPageId] = currentRects;
             renderRects();
+          });
+          $d.on("click", ".play", function (e) {
+            e.stopPropagation();
+            if (r.audio) {
+              audio.src = r.audio;
+              audio.play();
+            }
           });
         }
         function positionRect($d, r) {


### PR DESCRIPTION
## Summary
- allow admins to preview hotspot audio by clicking a new icon
- improve hotspot duplicate button icon
- ensure duplication copies current rectangle state

## Testing
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a8cb5c6188322b9c98bc852d3dc25